### PR TITLE
EE2.6 compatibility update: updated deprecated functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Thanks to the minify project for their CSS compressor and the JSMin project for 
 
 Changelog
 ---
-### Version 2.1.36
+### Version 2.1.4
 - Fixed Deprecation notice #27 for optimal compatibility with versions >= 2.6. 
 
 ### Version 2.1.3

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Thanks to the minify project for their CSS compressor and the JSMin project for 
 
 Changelog
 ---
+### Version 2.1.36
+- Fixed Deprecation notice #27 for optimal compatibility with versions >= 2.6. 
+
 ### Version 2.1.3
 - Fixed Bug #23. Updated LessPHP to support the latest version of Twitter Bootsrap.
 

--- a/ext.automin.php
+++ b/ext.automin.php
@@ -31,7 +31,7 @@ class Automin_ext {
 	public $docs_url		= 'https://github.com/bunchjesse/AutoMin';
 	public $name			= 'AutoMin';
 	public $settings_exist	= 'n';
-	public $version			= '2.1.36';
+	public $version			= '2.1.4';
 
 	private $EE;
 

--- a/ext.automin.php
+++ b/ext.automin.php
@@ -31,7 +31,7 @@ class Automin_ext {
 	public $docs_url		= 'https://github.com/bunchjesse/AutoMin';
 	public $name			= 'AutoMin';
 	public $settings_exist	= 'n';
-	public $version			= '2.1.3';
+	public $version			= '2.1.36';
 
 	private $EE;
 

--- a/libraries/automin_caching_library.php
+++ b/libraries/automin_caching_library.php
@@ -102,7 +102,14 @@ class Automin_caching_library {
 	*/
 	private function get_cache_file_path($cache_key) {
 		$cache_path = $this->EE->automin_model->get_cache_path();
-		return $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
+
+		if (version_compare(APP_VER, '2.6', '>=')) {
+			$sFixedslashes = $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
+		} else {
+			$sFixedslashes = $this->EE->functions->remove_double_slashes("$cache_path/$cache_key");
+		}
+
+		return $sFixedslashes;
 	}
 
 	/**
@@ -113,7 +120,14 @@ class Automin_caching_library {
 	*/
 	private function _get_cache_url_path($cache_key) {
 		$cache_path = $this->EE->automin_model->get_cache_url();
-		return $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
+		
+		if (version_compare(APP_VER, '2.6', '>=')) {
+			$sFixedslashes = $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
+		} else {
+			$sFixedslashes = $this->EE->functions->remove_double_slashes("$cache_path/$cache_key");
+		}
+		
+		return $sFixedslashes;
 	}
 
 

--- a/libraries/automin_caching_library.php
+++ b/libraries/automin_caching_library.php
@@ -113,7 +113,7 @@ class Automin_caching_library {
 	*/
 	private function _get_cache_url_path($cache_key) {
 		$cache_path = $this->EE->automin_model->get_cache_url();
-		return $this->EE->functions->remove_double_slashes("$cache_path/$cache_key");
+		return $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
 	}
 
 

--- a/libraries/automin_caching_library.php
+++ b/libraries/automin_caching_library.php
@@ -104,7 +104,8 @@ class Automin_caching_library {
 		$cache_path = $this->EE->automin_model->get_cache_path();
 
 		if (version_compare(APP_VER, '2.6', '>=')) {
-			$sFixedslashes = $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
+			$this->EE->load->helper('string');
+			$sFixedslashes = reduce_double_slashes("$cache_path/$cache_key");
 		} else {
 			$sFixedslashes = $this->EE->functions->remove_double_slashes("$cache_path/$cache_key");
 		}
@@ -122,7 +123,8 @@ class Automin_caching_library {
 		$cache_path = $this->EE->automin_model->get_cache_url();
 		
 		if (version_compare(APP_VER, '2.6', '>=')) {
-			$sFixedslashes = $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
+			$this->EE->load->helper('string');
+			$sFixedslashes = reduce_double_slashes("$cache_path/$cache_key");
 		} else {
 			$sFixedslashes = $this->EE->functions->remove_double_slashes("$cache_path/$cache_key");
 		}

--- a/libraries/automin_caching_library.php
+++ b/libraries/automin_caching_library.php
@@ -102,7 +102,7 @@ class Automin_caching_library {
 	*/
 	private function get_cache_file_path($cache_key) {
 		$cache_path = $this->EE->automin_model->get_cache_path();
-		return $this->EE->functions->remove_double_slashes("$cache_path/$cache_key");
+		return $this->EE->functions->reduce_double_slashes("$cache_path/$cache_key");
 	}
 
 	/**

--- a/mcp.automin.php
+++ b/mcp.automin.php
@@ -51,7 +51,11 @@ class Automin_mcp {
 	 */
 	public function index() {
 
-		$this->EE->cp->set_variable('cp_page_title', lang('automin_module_name'));
+	        if (version_compare(APP_VER, '2.6', '>=')) {
+			$this->EE->cp->cp_page_title = lang('automin_module_name');
+	        } else {
+			$this->EE->cp->set_variable('cp_page_title', lang('automin_module_name'));
+	        }
 
 		return $this->EE->load->view('settings', array(
 			'form_action' => $this->_form_url.AMP.'method=index_submit',

--- a/mod.automin.php
+++ b/mod.automin.php
@@ -499,8 +499,13 @@ class Automin {
 			$file_path = $_SERVER['DOCUMENT_ROOT'] . $file_path;
 		}
 
-		return $this->EE->functions->reduce_double_slashes($file_path);
-
+		if (version_compare(APP_VER, '2.6', '>=')) {
+			$sFixedslashes = $this->EE->functions->reduce_double_slashes($file_path);
+		} else {
+			$sFixedslashes = $this->EE->functions->remove_double_slashes($file_path);
+		}
+		
+		return $sFixedslashes;
 	}
 	
 	/**

--- a/mod.automin.php
+++ b/mod.automin.php
@@ -499,7 +499,7 @@ class Automin {
 			$file_path = $_SERVER['DOCUMENT_ROOT'] . $file_path;
 		}
 
-		return $this->EE->functions->remove_double_slashes($file_path);
+		return $this->EE->functions->reduce_double_slashes($file_path);
 
 	}
 	

--- a/mod.automin.php
+++ b/mod.automin.php
@@ -500,7 +500,8 @@ class Automin {
 		}
 
 		if (version_compare(APP_VER, '2.6', '>=')) {
-			$sFixedslashes = $this->EE->functions->reduce_double_slashes($file_path);
+			$this->EE->load->helper('string');
+			$sFixedslashes = reduce_double_slashes($file_path);
 		} else {
 			$sFixedslashes = $this->EE->functions->remove_double_slashes($file_path);
 		}

--- a/upd.automin.php
+++ b/upd.automin.php
@@ -32,7 +32,7 @@ class Automin_upd {
 	 * @var string
 	 * @author Jesse Bunch
 	*/
-	public $version = '2.1.36';
+	public $version = '2.1.4';
 
 	/**
 	 * Holds the EE instance

--- a/upd.automin.php
+++ b/upd.automin.php
@@ -32,7 +32,7 @@ class Automin_upd {
 	 * @var string
 	 * @author Jesse Bunch
 	*/
-	public $version = '2.1.3';
+	public $version = '2.1.36';
 
 	/**
 	 * Holds the EE instance


### PR DESCRIPTION
Replaced [remove_double_slashes] and [set_variable], with backwards compatibility. Took me a while to figure out why it wasn't working, but you need to turn off gzip compression in EE if you get a 330 error after changing this. 
